### PR TITLE
Centralised validating script

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,21 @@ Get path to a service definitions paths:
 ['/usr/local/lib/python3.8/site-packages/alsdkdefs/apis/aerta/aerta.v1.yaml']
 ```
 
+#### Quick validation of a definition
+
+While YAML definition is developed apart from the current package and current repo,
+it is required to validate it prior to push, please add this to your `Makefile` 
+in order to achieve quick validation:
+
+`curl -s https://raw.githubusercontent.com/alertlogic/alertlogic-sdk-definitions/master/scripts/validate_my_definition.sh | bash -s <path/to/definition/yaml>`
+
+It is recommended to invoke it via curl, since validation of the definitions might be extended with time.
+Script requires `python3` to be available in the system.
+
+Validation checks:
+* YAML of a definition is valid
+* Definition passes OpenAPI 3 schema validation
+
 ### Development
 
 Please submit a PR. Please note that API definitions are updated automatically and any changes to it will be overwritten, see:

--- a/scripts/validate_my_definition.py
+++ b/scripts/validate_my_definition.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+import jsonschema
+import yaml
+from yaml import YAMLError
+from jsonschema.exceptions import ValidationError
+import requests
+from argparse import ArgumentParser
+
+OPENAPI_SCHEMA_URL = 'https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/schemas/v3.0/schema.json'
+
+if __name__ == "__main__":
+    parser = ArgumentParser(description="Validates OpenAPI YAML developed for Alert Logic SDK")
+    parser.add_argument("-f", "--definition_file", dest="definition", required=True,
+                        help="Filename of a definition to test")
+    options = parser.parse_args()
+    r = requests.get(OPENAPI_SCHEMA_URL)
+    schema = r.json()
+    with open(options.definition, "r") as f:
+        spec = f.read()
+    if spec:
+        try:
+            obj = yaml.load(spec, Loader=yaml.SafeLoader)
+            jsonschema.validate(obj, schema)
+        except YAMLError as e:
+            print(f"Validation has failed - failed to load YAML {e}")
+            exit(1)
+        except ValidationError as e:
+            print(f"Validation has failed - schema validation has failed {e}")
+            exit(1)
+        print("Validation passed")
+    else:
+        print("Input is empty")
+        exit(1)

--- a/scripts/validate_my_definition.sh
+++ b/scripts/validate_my_definition.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set +e
+
+export TEMP=$(mktemp -d -t alertlogic-sdk-definitions-validation-XXXX)
+
+if python3 -m venv $TEMP; then
+  source $TEMP/bin/activate
+  pip3 install requests jsonschema PyYaml
+  curl https://raw.githubusercontent.com/alertlogic/alertlogic-sdk-definitions/validation-script/scripts/validate_my_definition.py -o $TEMP/validate_my_definition.py
+  python3 $TEMP/validate_my_definition.py -f $1 && rm -rf $TEMP
+fi


### PR DESCRIPTION
### Problem 
Easy way of validating  SDK yamls is required leaving no traces in the target system(to be used during services Open api development)

### Resolution
Add a script invoked via curl
Script is executed in isolated python virtual env, then venv is disposed.

