### PR TITLE
Handle uris

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,24 @@ jobs:
     python: 3.8
     install: pip install -U tox-travis
     script: tox
+  - python: 3.8
+    install:
+      - pip install ./
+    script: python scripts/validate_my_definition.py -d alsdkdefs/apis/assets_query/
   - python: 3.7
     install: pip install -U tox-travis
     script: tox
+  - stage: test_other_os
+    language: sh
+    python: 3
+    before_install:
+      - choco install python3
+      - export PATH="/c/Python38:/c/Python38/Scripts:$PATH"
+      - python -m pip install --upgrade pip wheel
+      - python -m pip install -r requirements.txt
+    name: 'Run python tests on windows'
+    script: python -m unittest
+    os: windows
   - stage: merge-automated-prs
     name: "(Pipeline Stage 1)Merge pull request produced by automation"
     if: "(fork = false) AND (head_branch =~ /^auto-update-\\d*/) AND (type = pull_request)"

--- a/tests/test_apis_validate.py
+++ b/tests/test_apis_validate.py
@@ -18,5 +18,5 @@ class TestServiceDefs(unittest.TestCase):
             print("Validating ", service)
             for defintion_file in alsdkdefs.get_service_defs(service):
                 print("Validating def", defintion_file)
-                obj = alsdkdefs.get_spec(defintion_file)
+                obj = alsdkdefs.get_spec(alsdkdefs.make_file_uri(defintion_file))
                 alsdkdefs.validate(obj, defintion_file)


### PR DESCRIPTION
### Problem 
Passing full file uri instead of directory where file resides to ref resolver breaks library on windows
It's more convenient to handle resource identifiers using URIs and loading resources using urllib using common code

### Resolution
Convert input os specific paths to uri
Handle further resource identification using uris internally 
Add tests for windows and macos