### PR TITLE
pyyaml: pin to 5.4.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 jsonschema[format_nongpl]==3.2.0
-pyyaml>=5.4.1
+pyyaml==5.4.1
 requests>=2.18
 jsonmerge>=1.8.0


### PR DESCRIPTION
Letting pyyaml float above 5.4.1 breaks something in the build process.