### PR TITLE
pin urllib3 to fix urllib3 2.0 issues with ssl on build images

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 jsonschema[format_nongpl]==3.2.0
 pyyaml==5.4.1
 requests>=2.18
+urllib3<2
 jsonmerge>=1.8.0

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 with open('README.md') as readme_file:
     readme = readme_file.read()
 
-requirements = ['jsonschema[format_nongpl]==3.2.0', 'pyyaml>=5.4.1', 'requests>=2.18', 'jsonmerge>=1.8.0']
+requirements = ['jsonschema[format_nongpl]==3.2.0', 'pyyaml>=5.4.1', 'requests>=2.18', 'urllib3<2', 'jsonmerge>=1.8.0']
 
 setup(
     name='alertlogic-sdk-definitions',


### PR DESCRIPTION
assets-query and iris have reported build issues related to alsdkdefs. These seems to be due to the latest version of requests unpinning urllib3, and the latest version of urllib3 being pulled in being incompatible with the version of ssl in the build images.