### PR TITLE
Allow the use of python 3.10 and 3.9

### DIFF
--- a/scripts/validate_my_definition.sh
+++ b/scripts/validate_my_definition.sh
@@ -3,7 +3,11 @@ set -e
 
 export TEMP=$(mktemp -d -t alertlogic-sdk-definitions-validation-XXXX)
 
-if command -v python3.8; then
+if command -v python3.10; then
+  PYTHON=python3.10
+elif command -v python3.9; then
+  PYTHON=python3.9
+elif command -v python3.8; then
   PYTHON=python3.8
 elif command -v python3.7; then
   PYTHON=python3.7


### PR DESCRIPTION
Validate_my_definition script seems to be broken on python 3.7, while we investigate add support for python 3.9 and 3.10 as they seem to work and are included in the makeincl image.