### PR TITLE
Pin setuptools-scm to below version 8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4,<8"]
 
 [tool.setuptools_scm]
 write_to = "alsdkdefs/version.py"


### PR DESCRIPTION
setuptools-scm v8 was released after v0.1.128 of the alcli which worked and before v0.1.129 which didn't. 
There error was
```
 File "/Users/james.bellamy/.pyenv/versions/3.9.12/bin/alcli", line 5, in <module>
    from alcli.alertlogic_cli import main
  File "/Users/james.bellamy/.pyenv/versions/3.9.12/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/alcli/alertlogic_cli.py", line 37, in <module>
    from alsdkdefs.version import version as alsdkdefs_version
ModuleNotFoundError: No module named 'alsdkdefs.version'
```

which relates to the version number of this repo. 

setuptools-scm is responsible for the version number so it's probably the cause of the error