### PR TITLE
Update Schema URL to point to stable openAPI location

### DIFF
--- a/alsdkdefs/__init__.py
+++ b/alsdkdefs/__init__.py
@@ -20,7 +20,7 @@ try:
 except ImportError:
     DEV_SDK_DEFS = False
 
-OPENAPI_SCHEMA_URL = 'https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/schemas/v3.0/schema.json'
+OPENAPI_SCHEMA_URL = 'https://spec.openapis.org/oas/3.0/schema/2021-09-28'
 OPENAPI_SCHEMA_FILE = 'openapi_schema.json'
 URI_SCHEMES = ['file', 'http', 'https']
 


### PR DESCRIPTION
OpenAPI Specification project has been recently updated to remove JSON schemas from the project and utilize only the YAML versions https://github.com/OAI/OpenAPI-Specification/pull/4137
One of the maintainers of the Specification project indicated in a related PR that raw schemas from the project should not be used directly. Instead, consumers should pull the schemas from their stable published location e.g. https://github.com/SchemaStore/schemastore/pull/4159
This change updates the schema URL to point to the stable location.